### PR TITLE
カードリストを垂直方向に動かしたときのparallax実装をBottomSheetとCoordinatorLayout.Behaviorで作り直し

### DIFF
--- a/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ParallaxBehavior.kt
+++ b/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ParallaxBehavior.kt
@@ -1,0 +1,27 @@
+package io.github.yusukeiwaki.better_always_drink.shop_list
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+
+class ParallaxBehavior<V : View>(context: Context, attrs: AttributeSet) : CoordinatorLayout.Behavior<V>(context, attrs) {
+
+    override fun layoutDependsOn(parent: CoordinatorLayout, child: V, dependency: View): Boolean {
+        try {
+            BottomSheetBehavior.from(dependency)
+        } catch (exception: IllegalArgumentException) {
+            return false
+        }
+
+        return true
+    }
+
+    override fun onDependentViewChanged(parent: CoordinatorLayout, child: V, dependency: View): Boolean {
+        val bottomSheetOffset = parent.bottom - dependency.top
+        child.translationY = - bottomSheetOffset.toFloat() / 2
+        return true
+    }
+}

--- a/app/src/main/res/layout/activity_shop_list.xml
+++ b/app/src/main/res/layout/activity_shop_list.xml
@@ -1,21 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:fitsSystemWindows="true"
     app:statusBarBackground="@color/colorPrimaryDark"
     tools:context=".shop_list.ShopListActivity">
     <fragment
         android:id="@+id/map"
         android:name="com.google.android.gms.maps.SupportMapFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_behavior=".shop_list.ParallaxBehavior"/>
 
-    <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/view_pager"
+    <FrameLayout
+        android:id="@+id/bottom_sheet_container"
         android:layout_width="match_parent"
-        android:layout_height="320dp"
-        android:layout_gravity="bottom"/>
+        android:layout_height="match_parent"
+        android:layout_gravity="bottom"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+        app:behavior_hideable="true"
+        app:behavior_peekHeight="320dp">
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/view_pager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+    </FrameLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
![alwaysdrink](https://user-images.githubusercontent.com/11763113/66943927-17ad5f00-f087-11e9-84d2-999d30650dde.gif)

基本動作は変えず、

* いざというときに拡大できる
* スワイプダウンで閉じることもできる

あたりを達成するために、独自実装よりはボトムシートかなー。ということで置き換えた。