### PR TITLE
Dockerでアプリをビルドできるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+FROM alpine
+
+# add glibc (see: https://hub.docker.com/r/frolvlad/alpine-glibc/dockerfile)
+RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
+    ALPINE_GLIBC_PACKAGE_VERSION="2.29-r0" && \
+    ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
+    ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
+    ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
+    apk add --no-cache --virtual=.build-dependencies wget ca-certificates && \
+    echo \
+        "-----BEGIN PUBLIC KEY-----\
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApZ2u1KJKUu/fW4A25y9m\
+        y70AGEa/J3Wi5ibNVGNn1gT1r0VfgeWd0pUybS4UmcHdiNzxJPgoWQhV2SSW1JYu\
+        tOqKZF5QSN6X937PTUpNBjUvLtTQ1ve1fp39uf/lEXPpFpOPL88LKnDBgbh7wkCp\
+        m2KzLVGChf83MS0ShL6G9EQIAUxLm99VpgRjwqTQ/KfzGtpke1wqws4au0Ab4qPY\
+        KXvMLSPLUp7cfulWvhmZSegr5AdhNw5KNizPqCJT8ZrGvgHypXyiFvvAH5YRtSsc\
+        Zvo9GI2e2MaZyo9/lvb+LbLEJZKEQckqRj4P26gmASrZEPStwc+yqy1ShHLA0j6m\
+        1QIDAQAB\
+        -----END PUBLIC KEY-----" | sed 's/   */\n/g' > "/etc/apk/keys/sgerrand.rsa.pub" && \
+    wget \
+        "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
+        "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
+        "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
+    apk add --no-cache \
+        "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
+        "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
+        "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
+    \
+    rm "/etc/apk/keys/sgerrand.rsa.pub" && \
+    /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true && \
+    echo "export LANG=$LANG" > /etc/profile.d/locale.sh && \
+    \
+    apk del glibc-i18n && \
+    \
+    rm "/root/.wget-hsts" && \
+    apk del .build-dependencies && \
+    rm \
+        "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
+        "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
+        "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME"
+
+
+# Android SDK
+RUN apk add --no-cache openjdk8 wget unzip
+RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && unzip -d /usr/local/android sdk-tools-linux-4333796.zip && rm sdk-tools-linux-4333796.zip
+
+ENV JAVA_HOME /usr/lib/jvm/default-jvm
+ENV ANDROID_HOME /usr/local/android
+ENV PATH /usr/local/android/tools:/usr/local/android/tools/bin:/usr/local/android/platform-tools:/usr/local/android/build-tools/29.0.1:/usr/lib/jvm/default-jvm/bin:$PATH
+
+RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
+RUN yes | sdkmanager --licenses
+RUN sdkmanager "tools" "platform-tools" "build-tools;29.0.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  android-build:
+    build: .
+    image: docker-android-build
+    volumes:
+      - .:/android
+      - gradle-cache:/root/.gradle
+      - ~/.android/debug.keystore:/root/.android/debug.keystore:ro # CIで使うときになったら真面目に考える
+    working_dir: /android
+    command: ./gradlew assembleDebug
+
+volumes:
+  gradle-cache:
+    driver: local


### PR DESCRIPTION
そのうちGitHub Actionsを導入するため、前準備としてDockerfileとcomposeファイルをGit管理しておく。

```
$ docker-compose up
Creating alwaysdrink_mylauncher_android-build_1 ... done
Attaching to alwaysdrink_mylauncher_android-build_1
android-build_1  | Starting a Gradle Daemon, 1 incompatible and 1 stopped Daemons could not be reused, use --status for details
android-build_1  | Checking the license for package Android SDK Platform 29 in /usr/local/android/licenses
 :
 :
android-build_1  | > Task :launcher_icon:stripDebugDebugSymbols UP-TO-DATE
android-build_1  | > Task :launcher_icon:transformNativeLibsWithIntermediateJniLibsForDebug UP-TO-DATE
android-build_1  | > Task :app:mergeDebugNativeLibs UP-TO-DATE
android-build_1  | > Task :app:stripDebugDebugSymbols UP-TO-DATE
android-build_1  | > Task :app:packageDebug UP-TO-DATE
android-build_1  | > Task :app:assembleDebug UP-TO-DATE
android-build_1  | > Task :launcher_icon:extractDebugAnnotations UP-TO-DATE
android-build_1  | > Task :launcher_icon:mergeDebugGeneratedProguardFiles UP-TO-DATE
android-build_1  | > Task :launcher_icon:mergeDebugConsumerProguardFiles UP-TO-DATE
android-build_1  | > Task :launcher_icon:prepareLintJarForPublish UP-TO-DATE
android-build_1  | > Task :launcher_icon:mergeDebugJavaResource UP-TO-DATE
android-build_1  | > Task :launcher_icon:transformClassesAndResourcesWithSyncLibJarsForDebug UP-TO-DATE
android-build_1  | > Task :launcher_icon:transformNativeLibsWithSyncJniLibsForDebug UP-TO-DATE
android-build_1  | > Task :launcher_icon:bundleDebugAar UP-TO-DATE
android-build_1  | > Task :launcher_icon:compileDebugSources UP-TO-DATE
android-build_1  | > Task :launcher_icon:assembleDebug UP-TO-DATE
android-build_1  | 
android-build_1  | BUILD SUCCESSFUL in 44s
android-build_1  | 61 actionable tasks: 61 up-to-date
```