### PR TITLE
画面回転したときにParallaxのオフセット値が正しく復元されないのを修正

### DIFF
--- a/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ParallaxBehavior.kt
+++ b/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ParallaxBehavior.kt
@@ -23,7 +23,7 @@ class ParallaxBehavior<V : View>(context: Context, attrs: AttributeSet) : Coordi
         val bottomSheet = BottomSheetBehavior.from(dependency)
 
         val bottomSheetOffset = parent.bottom - dependency.top
-        if (bottomSheetOffset < bottomSheet.peekHeight) {
+        if (bottomSheetOffset <= bottomSheet.peekHeight) {
             child.translationY = -bottomSheetOffset.toFloat() / 2
         }
 


### PR DESCRIPTION
closes #12 

```    override fun onDependentViewChanged(parent: CoordinatorLayout, child: V, dependency: View): Boolean {
        val bottomSheet = BottomSheetBehavior.from(dependency)

        val bottomSheetOffset = parent.bottom - dependency.top
        if (bottomSheetOffset < bottomSheet.peekHeight) {
            child.translationY = -bottomSheetOffset.toFloat() / 2
        }
```

事象発生時、bottomSheetOffsetがちょうどpeekHeightの値に一致している。
なので、変更前の分岐条件↑だと、translationYが設定されていなかった。