### PR TITLE
ShopListViewModelのなかで、Mapの最後の位置・ズームレベルを記録を別のViewModelに切り出す

### DIFF
--- a/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/MapFragmentViewModel.kt
+++ b/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/MapFragmentViewModel.kt
@@ -1,0 +1,25 @@
+package io.github.yusukeiwaki.better_always_drink.shop_list
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.distinctUntilChanged
+import com.google.android.gms.maps.model.LatLng
+
+class MapFragmentViewModel: ViewModel() {
+    private val _lastLatLng = MutableLiveData<LatLng>()
+    private val _lastZoomLevel = MutableLiveData<Float>()
+
+    val lastLatLng: LiveData<LatLng> get() = _lastLatLng.distinctUntilChanged()
+    val lastLatLngValue: LatLng? get() = _lastLatLng.value
+    val lastZoomLevel: LiveData<Float> get() = _lastZoomLevel.distinctUntilChanged()
+    val lastZoomLevelValue: Float? get() = _lastZoomLevel.value
+
+    fun onLatLngChanged(newLatLng: LatLng) {
+        _lastLatLng.value = newLatLng
+    }
+
+    fun onZoomLevelChanged(newZoomLevel: Float) {
+        _lastZoomLevel.value = newZoomLevel
+    }
+}

--- a/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ShopListActivity.kt
+++ b/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ShopListActivity.kt
@@ -22,6 +22,7 @@ class ShopListActivity : AppCompatActivity(), OnMapReadyCallback {
     private lateinit var googleMap: GoogleMap
     private lateinit var bottomSheet: BottomSheetBehavior<View>
     private val viewModel: ShopListViewModel by viewModels()
+    private val mapViewModel: MapFragmentViewModel by viewModels()
     private lateinit var viewPagerAdapter: ShopListAdapter
 
     private val alwaysShopUuid: String? by AlwaysPreference(this)
@@ -79,14 +80,16 @@ class ShopListActivity : AppCompatActivity(), OnMapReadyCallback {
     override fun onMapReady(map: GoogleMap) {
         googleMap = map
         val shopListClusterManager = ClusterManager<Shop>(this, googleMap)
-        val shopListClusterRenderer = ShopListClusterRenderer(this, googleMap, shopListClusterManager, viewModel)
+        val shopListClusterRenderer = ShopListClusterRenderer(this, googleMap, shopListClusterManager, mapViewModel)
         shopListClusterManager.renderer = shopListClusterRenderer
         googleMap.setOnCameraIdleListener(shopListClusterManager)
         googleMap.setOnMarkerClickListener(shopListClusterManager)
         googleMap.setOnInfoWindowClickListener(shopListClusterManager)
 
         // 初期位置を決めないと、アフリカの海が表示されるので、適当に初期位置を設定しておく。
-        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(34.6870728, 135.0490244),5.0f))
+        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(
+            mapViewModel.lastLatLngValue ?: LatLng(34.6870728, 135.0490244),
+            mapViewModel.lastZoomLevelValue ?: 5.0f))
 
         viewModel.focusedShop.observe(this) { focusedShop ->
             shopListClusterRenderer.updateSelectedShop(focusedShop)

--- a/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ShopListClusterRenderer.kt
+++ b/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ShopListClusterRenderer.kt
@@ -24,7 +24,7 @@ class ShopListClusterRenderer(
     private val context: Context,
     private val googleMap: GoogleMap,
     private val clusterManager: ClusterManager<Shop>,
-    private val viewModel: ShopListViewModel
+    private val mapViewModel: MapFragmentViewModel
 ) : DefaultClusterRenderer<Shop>(context, googleMap, clusterManager), GoogleMap.OnCameraIdleListener {
     private var serviceAreaList: List<ServiceArea>? = null
     private var lastZoomLevel: Float? = null
@@ -39,8 +39,8 @@ class ShopListClusterRenderer(
 
     override fun onCameraIdle() {
         val cameraPosition = googleMap.cameraPosition
-        viewModel.onLatLngChanged(cameraPosition.target)
-        viewModel.onZoomLevelChanged(cameraPosition.zoom)
+        mapViewModel.onLatLngChanged(cameraPosition.target)
+        mapViewModel.onZoomLevelChanged(cameraPosition.zoom)
     }
 
     fun updateServiceAreaList(newServiceAreaList: List<ServiceArea>) {
@@ -66,7 +66,7 @@ class ShopListClusterRenderer(
     }
 
     override fun shouldRenderAsCluster(cluster: Cluster<Shop>?): Boolean {
-        return viewModel.lastZoomLevelValue?.let { it < ZOOM_THRESHOLD } ?: true
+        return mapViewModel.lastZoomLevelValue?.let { it < ZOOM_THRESHOLD } ?: true
     }
 
     override fun onBeforeClusterRendered(cluster: Cluster<Shop>?, markerOptions: MarkerOptions?) {

--- a/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ShopListViewModel.kt
+++ b/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/ShopListViewModel.kt
@@ -2,7 +2,6 @@ package io.github.yusukeiwaki.better_always_drink.shop_list
 
 import android.util.Log
 import androidx.lifecycle.*
-import com.google.android.gms.maps.model.LatLng
 import io.github.yusukeiwaki.better_always_drink.api.AlwaysApiClient
 import io.github.yusukeiwaki.better_always_drink.model.ServiceArea
 import io.github.yusukeiwaki.better_always_drink.model.Shop
@@ -18,9 +17,6 @@ class ShopListViewModel : ViewModel() {
     private val _selectedServiceArea = MutableLiveData<ServiceArea?>()
     private val _focusedShop = MutableLiveData<Shop?>()
 
-    private val _lastLatLng = MutableLiveData<LatLng>()
-    private val _lastZoomLevel = MutableLiveData<Float>()
-
     val serviceAreaList: LiveData<List<ServiceArea>> get() = _serviceAreaList
     val shopList: LiveData<List<Shop>> get() = _shopList
 
@@ -28,10 +24,6 @@ class ShopListViewModel : ViewModel() {
     val selectedServiceAreaValue get() = _selectedServiceArea.value
     val focusedShop: LiveData<Shop?> get() = _focusedShop.distinctUntilChanged()
     val hasFocusedShop get() = _focusedShop.value != null
-
-    val lastLatLng: LiveData<LatLng> get() = _lastLatLng.distinctUntilChanged()
-    val lastZoomLevel: LiveData<Float> get() = _lastZoomLevel.distinctUntilChanged()
-    val lastZoomLevelValue: Float? get() = _lastZoomLevel.value
 
     init {
         viewModelScope.launch {
@@ -103,13 +95,5 @@ class ShopListViewModel : ViewModel() {
             }
         }
         _focusedShop.value = newShop
-    }
-
-    fun onLatLngChanged(newLatLng: LatLng) {
-        _lastLatLng.value = newLatLng
-    }
-
-    fun onZoomLevelChanged(newZoomLevel: Float) {
-        _lastZoomLevel.value = newZoomLevel
     }
 }


### PR DESCRIPTION
ShopListViewModel がだいぶファットになってきているため、地図の最後の緯度経度・ズームレベルを記録するのを別のViewModelに切り出す。
ShopListClusterRendererは最後の緯度経度・ズームレベルを記録したり、ズーム率によってCluster表示するかどうかを判断したりするためだけにShopListViewModelを参照していたため、これをMapFragmentViewModelを参照する形に変えた。