### PR TITLE
画面回転したときにボトムシートの子Viewのリサイズが効いていなかったのを修正

### DIFF
--- a/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/BottomSheetChildResizingBehavior.kt
+++ b/app/src/main/java/io/github/yusukeiwaki/better_always_drink/shop_list/BottomSheetChildResizingBehavior.kt
@@ -5,20 +5,19 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import java.lang.ref.WeakReference
 
 class BottomSheetChildResizingBehavior<V : View>(context: Context, attrs: AttributeSet) : BottomSheetBehavior<V>(context, attrs) {
 
     private var parentRef: WeakReference<View> = WeakReference<View>(null)
-    private var resizingChildRef: WeakReference<View> = WeakReference<View>(null)
+    private var resizingTargetRef: WeakReference<View> = WeakReference<View>(null)
 
     override fun layoutDependsOn(parent: CoordinatorLayout, child: V, dependency: View): Boolean {
         (child as? ViewGroup)?.let { viewGroup ->
             if (viewGroup.childCount > 0) {
                 parentRef = WeakReference(parent)
-                resizingChildRef = WeakReference(viewGroup.getChildAt(0))
+                resizingTargetRef = WeakReference(viewGroup.getChildAt(0))
             }
         }
 
@@ -29,17 +28,28 @@ class BottomSheetChildResizingBehavior<V : View>(context: Context, attrs: Attrib
         // dispatchOnSlideをオーバーライドはできないので、BottomSheetCallbackを仕掛けて、そこでやる。
         addBottomSheetCallback(object: BottomSheetCallback() {
             override fun onSlide(bottomSheet: View, slideOffset: Float) {
-                parentRef.get()?.let { parent ->
-                    resizingChildRef.get()?.let { child ->
-                        val newHeight = parent.bottom - bottomSheet.top
-                        if (child.layoutParams.height != newHeight) {
-                            child.layoutParams = child.layoutParams.apply { height = newHeight }
-                        }
-                    }
-                }
+                onChildUpdated(bottomSheet)
             }
 
             override fun onStateChanged(bottomSheet: View, newState: Int) { }
         })
+    }
+
+    // 画面回転したときには onSlideはコールバックされないので、ここで救う。
+    override fun onLayoutChild(parent: CoordinatorLayout, child: V, layoutDirection: Int): Boolean {
+        return super.onLayoutChild(parent, child, layoutDirection).also {
+            onChildUpdated(child)
+        }
+    }
+
+    private fun onChildUpdated(bottomSheet: View) {
+        parentRef.get()?.let { parent ->
+            resizingTargetRef.get()?.let { resizingTarget ->
+                val newHeight = parent.bottom - bottomSheet.top
+                if (resizingTarget.layoutParams.height != newHeight) {
+                    resizingTarget.layoutParams = resizingTarget.layoutParams.apply { height = newHeight }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
closes #16 
![alwaysdrink](https://user-images.githubusercontent.com/11763113/67147234-2b96d200-f2ce-11e9-92ff-86472361afc4.gif)
